### PR TITLE
Avoid calling in the same thread.

### DIFF
--- a/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/async/AsyncContext.java
+++ b/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/async/AsyncContext.java
@@ -12,11 +12,21 @@ package com.nepxion.discovery.agent.async;
 public class AsyncContext {
     private Object[] objects;
 
+    /**
+     * Record the original thread and compare it with the thread that called runnable/callable.
+     */
+    private Thread originThread;
+
     public AsyncContext(Object[] objects) {
         this.objects = objects;
+        this.originThread = Thread.currentThread();
     }
 
     public Object[] getObjects() {
         return objects;
+    }
+
+    public Thread getOriginThread() {
+        return originThread;
     }
 }

--- a/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/plugin/spring/async/WrapCallable.java
+++ b/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/plugin/spring/async/WrapCallable.java
@@ -27,6 +27,13 @@ public class WrapCallable<T> implements AsyncContextAccessor, Callable<T> {
 
     @Override
     public T call() throws Exception {
+
+        //Avoid calling in the same thread.
+        if (asyncContext.getOriginThread().equals(Thread.currentThread())) {
+            return callable.call();
+        }
+
+        //Call the original method and copy some objects held by ThreadLocal.
         Object[] objects = asyncContext.getObjects();
         ThreadLocalCopier.before(objects);
         try {

--- a/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/plugin/thread/interceptor/ThreadCallInterceptor.java
+++ b/discovery-agent-starter/src/main/java/com/nepxion/discovery/agent/plugin/thread/interceptor/ThreadCallInterceptor.java
@@ -21,6 +21,10 @@ public class ThreadCallInterceptor {
             if (null == asyncContext) {
                 return;
             }
+            //Avoid calling in the same thread.
+            if (asyncContext.getOriginThread().equals(Thread.currentThread())) {
+                return;
+            }
             Object[] objects = asyncContext.getObjects();
             ThreadLocalCopier.before(objects);
         }
@@ -28,6 +32,15 @@ public class ThreadCallInterceptor {
 
     public static void after(Object object) {
         if (object instanceof AsyncContextAccessor) {
+            AsyncContextAccessor asyncContextAccessor = (AsyncContextAccessor) object;
+            AsyncContext asyncContext = asyncContextAccessor.getAsyncContext();
+            if (null == asyncContext) {
+                return;
+            }
+            //Avoid calling in the same thread.
+            if (asyncContext.getOriginThread().equals(Thread.currentThread())) {
+                return;
+            }
             ThreadLocalCopier.after();
         }
     }


### PR DESCRIPTION
Record the original thread and compare it with the thread that called runnable/callable.